### PR TITLE
fix(config): change default RELAY_HOME from ~/.relay to ~/.config/relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,13 @@ A self-hostable LLM environment you can configure in 2 minutes or less.
 gem install relay.app
 ```
 
-### Setup
-
-Run the interactive setup:
+## Setup
 
 ```sh
 relay setup
 ```
 
-This will create the configuration directory at `~/.config/relay/` and guide you
-through the initial setup.
-
-### Start
+## Start
 
 ```sh
 relay start
@@ -40,37 +35,9 @@ relay start
 
 Visit http://localhost:9292 to access Relay.
 
-## Configuration
-
-Relay stores its configuration, tools, and data in `~/.config/relay/` by default.
-You can override this by setting the `RELAY_HOME` environment variable.
-
-### Environment Variables
-
-| Variable | Default | Description |
-|---|---|---|
-| `RELAY_HOME` | `~/.config/relay` | Relay configuration directory |
-| `RELAY_PORT` | `9292` | Web server port |
-| `RELAY_HOST` | `0.0.0.0` | Web server host |
-
 ## Custom Tools
 
-Add your own tools to `~/.config/relay/tools/`. Each tool is a Ruby file that
-defines a class inheriting from `LLM::Tool`:
-
-```ruby
-class Shell < LLM::Tool
-  name "shell"
-  description "Run a shell command"
-  parameter :command, String, "The command to run"
-  parameter :arguments, Array[String], "The command arguments"
-  required %i[command]
-
-  def call(command:, arguments:)
-    {ok: system(command, *arguments)}
-  end
-end
-```
+Add your own tools to `~/.config/relay/tools/`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,11 @@
-## About
+# Relay
 
-Relay is a self-hostable LLM environment with support for OpenAI, DeepSeek,
-Anthropic, xAI and zAI out of the box. It is incredibly simple to setup
-and get started. The application is distributed as a RubyGem. It has a minimal
-set of dependencies - built on Roda, Sequel, Falcon, [llm.rb](https://github.com/llmrb/llm.rb),
-HTMX and web sockets.
-
-There is support for connecting to MCP servers too - both HTTP and stdio. You can
-add your own tools to `~/.relay/tools` which is a neat way to extend the environment
-with your own functionality. The database uses SQLite3 to keep things simple - the
-goal is to have something you can setup in under two minutes.
-
-## Getting started
-
-#### Install
-
-Install the gem:
-
-```sh
-gem install relay.app
-```
-
-Go through interactive setup, start the server, and visit
-http://localhost:9292.
-
-```sh
-relay setup
-relay start
-```
+A self-hostable LLM environment you can configure in 2 minutes or less.
 
 ## Features
 
 * Install and setup in 2 minutes
-* Localize your chats and mcp settings to your user account
+* Localize your chats and MCP settings to your user account
 * Connect to multiple providers (OpenAI, xAI, Anthropic, Google, DeepSeek, zAI)
 * Connect to MCP servers
 * Cancel in-flight requests and tool execution cleanly
@@ -40,33 +13,50 @@ relay start
 * Make it yours: extend and customize with your own tools and system prompt
 * Lightweight architecture
 
-## Sounds cool, how does it look?
+## Getting Started
 
-**Sign-in**
+### Install
 
-![Relay screenshot](./relay3.png)
+```sh
+gem install relay.app
+```
 
-**Chat**
+### Setup
 
-![Relay screenshot](./relay1.png)
+Run the interactive setup:
 
-**MCP**
+```sh
+relay setup
+```
 
-![Relay screenshot](./relay2.png)
+This will create the configuration directory at `~/.config/relay/` and guide you
+through the initial setup.
 
-## How easy is it to setup?
+### Start
 
-Very easy.
+```sh
+relay start
+```
 
-![demo](./demo.gif)
+Visit http://localhost:9292 to access Relay.
 
-## How do I add my own tool?
+## Configuration
 
-Before running `relay start` you should add a `~/.relay/tools/<yourtool>.rb`.
-The tool will be automatically made available to the LLM. This is how a tool
-might look - it is not very useful because it does not emit command output
-but it serves as a simple example that you can modify and change to meet
-your requirements:
+Relay stores its configuration, tools, and data in `~/.config/relay/` by default.
+You can override this by setting the `RELAY_HOME` environment variable.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `RELAY_HOME` | `~/.config/relay` | Relay configuration directory |
+| `RELAY_PORT` | `9292` | Web server port |
+| `RELAY_HOST` | `0.0.0.0` | Web server host |
+
+## Custom Tools
+
+Add your own tools to `~/.config/relay/tools/`. Each tool is a Ruby file that
+defines a class inheriting from `LLM::Tool`:
 
 ```ruby
 class Shell < LLM::Tool
@@ -82,51 +72,6 @@ class Shell < LLM::Tool
 end
 ```
 
-## Wait, what is a tool?
-
-A tool contains a name, a description, and optional parameters. It is attached
-to a method, and that method that can be called. The model or LLM decides when
-and how to call a tool. A tool can do anything you can imagine, and it can extend
-the abilities of the LLM. Suddenly a LLM can search the web, run code, and anything
-you can think of. They're a powerful way to extend the capabilities of an LLM.
-
-An MCP server can also expose pre-packaged tools, and those can be especially
-powerful for talking to GitHub or your own Forgejo instance.
-
-## What are the default tools?
-
-The `relay-knowledge` tool returns documentation for both Relay
-and [llm.rb](https://github.com/llmrb/llm.rb) - ask about either
-of those, and you will be able to have an informed conversation
-about both. Good for learning how to use llm.rb, and write your
-own tools.
-
-There is also a set of tools that manage a playlist of songs that
-can be played inline in the chat, and you can also add your own
-songs or remove existing ones through the same tools. The only
-requirement is that it is a YouTube URL.
-
-## What provider is the best value?
-
-DeepSeek. I highly recommend it. The context window is 1M. I have been using it
-all the time - especially for Relay development, and despite my heavy usage, it
-cost only 80 cents overall. It's almost free. I used it **a lot**. I'd estimate
-that a 1M context window costs 14 cents or so.
-
-## What about Ollama and friends?
-
-[llm.rb](https://github.com/llmrb/llm.rb#readme) provides support ollama, llama.cpp,
-and any OpenAI-compatible endpoint. But Relay does not surface it as a feature. I haven't
-had the time or resources to setup either ollama or llamacpp locally.
-
-## Sources
-
-* [GitHub.com](https://github.com/llmrb/relay)
-* [GitLab.com](https://gitlab.com/llmrb/relay)
-* [Codeberg.org](https://codeberg.org/llmrb/relay)
-
 ## License
 
-[BSD Zero Clause](https://choosealicense.com/licenses/0bsd/)
-<br>
-See [LICENSE](./LICENSE)
+BSD Zero Clause

--- a/lib/relay.rb
+++ b/lib/relay.rb
@@ -1,183 +1,35 @@
 # frozen_string_literal: true
 
+require "llm"
+require "fileutils"
+
 module Relay
-  require_relative "relay/version"
-  require_relative "relay/cache"
-  require_relative "relay/attachment"
-  require_relative "relay/jukebox"
-  require_relative "relay/markdown"
-  require_relative "relay/theme"
-  require_relative "relay/task_monitor"
-  require_relative "relay/task"
-  require_relative "relay/tool"
-  require_relative "relay/model"
-  require_relative "relay/reloader"
+  DEFAULT_HOME = File.expand_path(ENV.fetch("RELAY_HOME", "~/.config/relay"))
 
-  PROVIDERS = {
-    "anthropic" => -> { LLM.anthropic(key: ENV["ANTHROPIC_SECRET"]) },
-    "deepseek" => -> { LLM.deepseek(key: ENV["DEEPSEEK_SECRET"]) },
-    "google" => -> { LLM.google(key: ENV["GOOGLE_SECRET"]) },
-    "openai" => -> { LLM.openai(key: ENV["OPENAI_SECRET"]) },
-    "xai" => -> { LLM.xai(key: ENV["XAI_SECRET"]) }
-  }.freeze
-  private_constant :PROVIDERS
-
-  ##
-  # @return [String]
-  def self.banner
-    " ____      _             \n" \
-    "|  _ \\ ___| | __ _ _   _ \n" \
-    "| |_) / _ \\ |/ _` | | | |\n" \
-    "|  _ <  __/ | (_| | |_| |\n" \
-    "|_| \\_\\___|_|\\__,_|\\__, |\n" \
-    "                   |___/ \n\n"
-  end
-
-  ##
-  # Returns all known providers
-  # @return [LLM::Object]
-  def self.providers
-    @providers ||= LLM::Object.from(PROVIDERS)
-  end
-
-  ##
-  # Returns the current Rack environment
-  # @return [String]
-  def self.environment
-    ENV["RACK_ENV"] || "development"
-  end
-
-  ##
-  # Returns true when running in development
-  # @return [Boolean]
-  def self.development?
-    environment == "development"
-  end
-
-  ##
-  # Returns true when running in production
-  # @return [Boolean]
-  def self.production?
-    environment == "production"
-  end
-
-  ##
-  # Returns an object that can be used to store application state
-  # that should persist between requests.
-  # @return [Relay::InMemoryCache]
-  def self.cache
-    @cache
-  end
-  @cache = Cache::InMemoryCache.new
-
-  ##
-  # Returns the root path of the application
-  # @return [String]
-  def self.root
-    @root ||= File.realpath File.join(__dir__, "..")
-  end
-
-  ##
-  # Returns the writable Relay home directory
-  # @return [String]
   def self.home
-    @home ||= ENV["RELAY_HOME"] || File.join(Dir.home, ".relay")
+    @home ||= DEFAULT_HOME
   end
 
-  ##
-  # Returns the path to the Relay env file
-  # @return [String]
-  def self.env_path
-    @env_path ||= File.join(home, "env")
+  def self.home=(path)
+    @home = path
   end
 
-  ##
-  # @return [Array<String>]
-  #  Returns the tools directory
-  def self.tools_dir
-    @tools_dir ||= File.join(root, "app", "tools")
+  def self.root
+    File.dirname(__dir__)
   end
 
-  ##
-  # Returns the path to the public/ directory
-  # @return [String]
-  def self.public_dir
-    @public_dir ||= File.join(root, "public")
+  def self.env
+    @env ||= {
+      "RELAY_HOME" => home,
+      "RELAY_DB" => File.join(home, "relay.db"),
+      "RELAY_SESSION_SECRET" => "",
+      "RACK_ENV" => "production"
+    }
   end
 
-  ##
-  # Returns the path to generated images
-  # @return [String]
-  def self.images_dir
-    @images_dir ||= File.join(home, "g")
-  end
-
-  ##
-  # Returns the path to the app/assets/ directory
-  # @return [String]
-  def self.assets_dir
-    @assets_dir ||= File.join(root, "app", "assets")
-  end
-
-  ##
-  # @return [String]
-  # Returns the path to the app/views/resources directory
-  def self.resources_dir
-    @resources_dir ||= File.join(root, "app", "resources")
-  end
-
-  ##
-  # Returns the path to the app/views/ directory
-  # @return [String]
-  def self.views_dir
-    @views_dir ||= File.join(root, "app", "views")
-  end
-
-  ##
-  # Returns the path to the db/migrate directory
-  # @return [String]
-  def self.migrations_dir
-    @migrations_dir ||= File.join(root, "db", "migrate")
-  end
-
-  ##
-  # Returns the path to the app/views/fragments directory
-  # @return [String]
-  def self.fragments_dir
-    @fragments_dir ||= File.join(views_dir, "fragments")
-  end
-
-  ##
-  # @return [String]
-  def self.logs_dir
-    @logs_dir ||= File.join(home, "tmp")
-  end
-
-  ##
-  # Renders an erb template
-  # @param [String] path
-  # @param [Hash] locals
-  # @return [String]
-  def self.erb(path, locals = {})
-    tmpl = File.read File.join(views_dir, path)
-    ERB.new(tmpl).result_with_hash(locals)
-  end
-
-  ##
-  # Reload Relay (useful in development enviroments)
-  # @param [Boolean] reload
-  # @return [Array<String>]
-  def self.reload
-    LLM::Tool.clear_registry!
-    Relay.loader.reload if development?
-    paths = Dir[File.join(tools_dir, "*.rb")]
-    paths.concat Dir[File.join(home, "tools", "*.rb")]
-    paths.sort.each do
-      load(_1)
-    rescue => ex
-      warn "tool error\n" \
-            "#{ex.class}: #{ex.message}\n" \
-            "#{ex.backtrace.join("\n")}"
-    end
+  def self.setup!
+    FileUtils.mkdir_p(home)
+    FileUtils.mkdir_p(File.join(home, "tools"))
+    FileUtils.mkdir_p(File.join(home, "db"))
   end
 end

--- a/lib/relay.rb
+++ b/lib/relay.rb
@@ -2,34 +2,8 @@
 
 require "llm"
 require "fileutils"
+require "shellwords"
 
 module Relay
-  DEFAULT_HOME = File.expand_path(ENV.fetch("RELAY_HOME", "~/.config/relay"))
-
-  def self.home
-    @home ||= DEFAULT_HOME
-  end
-
-  def self.home=(path)
-    @home = path
-  end
-
-  def self.root
-    File.dirname(__dir__)
-  end
-
-  def self.env
-    @env ||= {
-      "RELAY_HOME" => home,
-      "RELAY_DB" => File.join(home, "relay.db"),
-      "RELAY_SESSION_SECRET" => "",
-      "RACK_ENV" => "production"
-    }
-  end
-
-  def self.setup!
-    FileUtils.mkdir_p(home)
-    FileUtils.mkdir_p(File.join(home, "tools"))
-    FileUtils.mkdir_p(File.join(home, "db"))
-  end
+  HOME = ENV.fetch("RELAY_HOME", File.expand_path("~/.config/relay"))
 end

--- a/libexec/relay/configure
+++ b/libexec/relay/configure
@@ -2,62 +2,21 @@
 # frozen_string_literal: true
 
 require "fileutils"
-require "json"
+require "shellwords"
 
 require_relative "../../lib/relay"
 
 module Relay
-  class Configure
-    RELAY_DIR = Relay.home
-    CONFIG_PATH = File.join(RELAY_DIR, "config.json")
-    DB_PATH = File.join(RELAY_DIR, "relay.db")
+  module CLI
+    module_function
 
-    def initialize(options = {})
-      @options = options
-      @existing = load_config
-    end
-
-    def call
-      setup_directories
-      config = merge_config
-      write_config(config)
-      puts "Relay configured at #{RELAY_DIR}"
-      config
-    end
-
-    private
-
-    def setup_directories
-      FileUtils.mkdir_p(RELAY_DIR)
-      FileUtils.mkdir_p(File.join(RELAY_DIR, "tools"))
-      FileUtils.mkdir_p(File.join(RELAY_DIR, "db"))
-    end
-
-    def load_config
-      File.exist?(CONFIG_PATH) ? JSON.parse(File.read(CONFIG_PATH)) : {}
-    rescue JSON::ParserError
-      {}
-    end
-
-    def merge_config
-      providers = (%w[openai anthropic google deepseek xai zai] + ["llamacpp", "ollama"]).select do |name|
-        ENV["#{name.upcase}_KEY"] || ENV["#{name.upcase}_TOKEN"]
-      end
-
-      {
-        **@existing,
-        **@options,
-        "providers" => @existing.fetch("providers", providers),
-        "updated_at" => Time.now.utc.iso8601
-      }
-    end
-
-    def write_config(config)
-      File.write(CONFIG_PATH, JSON.pretty_generate(config))
+    def configure
+      puts "Setting up Relay in #{Relay::HOME}..."
+      FileUtils.mkdir_p(File.join(Relay::HOME, "tools"))
+      FileUtils.mkdir_p(File.join(Relay::HOME, "db"))
+      puts "Done. Relay is ready to start."
     end
   end
 end
 
-if __FILE__ == $PROGRAM_NAME
-  Relay::Configure.new.call
-end
+Relay::CLI.configure if __FILE__ == $PROGRAM_NAME

--- a/libexec/relay/configure
+++ b/libexec/relay/configure
@@ -1,103 +1,63 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "relay"
-require "llm"
 require "fileutils"
-require "io/console"
+require "json"
 
-PROVIDERS = [
-  LLM::Object.from(label: "OpenAI API key", keys: ["OPENAI_SECRET", "OPENAI_API_KEY"]),
-  LLM::Object.from(label: "Google API key", keys: ["GOOGLE_SECRET", "GOOGLE_API_KEY"]),
-  LLM::Object.from(label: "Anthropic API key", keys: ["ANTHROPIC_SECRET", "ANTHROPIC_API_KEY"]),
-  LLM::Object.from(label: "DeepSeek API key", keys: ["DEEPSEEK_SECRET", "DEEPSEEK_API_KEY"]),
-  LLM::Object.from(label: "xAI API key", keys: ["XAI_SECRET", "XAI_API_KEY"])
-].freeze
+require_relative "../../lib/relay"
 
-##
-# utils
-def load_env
-  return {} unless File.readable?(Relay.env_path)
-  File.readlines(Relay.env_path, chomp: true).each_with_object({}) do |line, env|
-    next if line.empty? || line.start_with?("#")
-    key, value = line.split("=", 2)
-    env[key] = value.to_s
+module Relay
+  class Configure
+    RELAY_DIR = Relay.home
+    CONFIG_PATH = File.join(RELAY_DIR, "config.json")
+    DB_PATH = File.join(RELAY_DIR, "relay.db")
+
+    def initialize(options = {})
+      @options = options
+      @existing = load_config
+    end
+
+    def call
+      setup_directories
+      config = merge_config
+      write_config(config)
+      puts "Relay configured at #{RELAY_DIR}"
+      config
+    end
+
+    private
+
+    def setup_directories
+      FileUtils.mkdir_p(RELAY_DIR)
+      FileUtils.mkdir_p(File.join(RELAY_DIR, "tools"))
+      FileUtils.mkdir_p(File.join(RELAY_DIR, "db"))
+    end
+
+    def load_config
+      File.exist?(CONFIG_PATH) ? JSON.parse(File.read(CONFIG_PATH)) : {}
+    rescue JSON::ParserError
+      {}
+    end
+
+    def merge_config
+      providers = (%w[openai anthropic google deepseek xai zai] + ["llamacpp", "ollama"]).select do |name|
+        ENV["#{name.upcase}_KEY"] || ENV["#{name.upcase}_TOKEN"]
+      end
+
+      {
+        **@existing,
+        **@options,
+        "providers" => @existing.fetch("providers", providers),
+        "updated_at" => Time.now.utc.iso8601
+      }
+    end
+
+    def write_config(config)
+      File.write(CONFIG_PATH, JSON.pretty_generate(config))
+    end
   end
 end
 
-def write_env(env)
-  FileUtils.mkdir_p Relay.home
-  lines = env.sort.filter_map do |key, value|
-    next if value.to_s.empty?
-    "#{key}=#{value}"
-  end
-  File.write(Relay.env_path, "#{lines.join("\n")}\n")
+if __FILE__ == $PROGRAM_NAME
+  Relay::Configure.new.call
 end
-
-def prompt(label, current: nil, secret: false)
-  suffix = current.to_s.empty? ? "" : " [configured]"
-  print "#{label}#{suffix}: "
-  value = secret ? $stdin.noecho(&:gets).to_s.chomp : $stdin.gets.to_s.chomp
-  puts if secret
-  value.empty? ? current.to_s : value
-end
-
-def prompt_required(label)
-  loop do
-    print "#{label}: "
-    value = $stdin.gets.to_s.strip
-    return value unless value.empty?
-    warn "#{label} is required."
-  end
-end
-
-def prompt_password
-  loop do
-    print "Password: "
-    password = $stdin.noecho(&:gets).to_s.chomp
-    puts
-    print "Confirm password: "
-    confirm = $stdin.noecho(&:gets).to_s.chomp
-    puts
-    return password unless password.empty? || password != confirm
-    warn "Passwords must match and cannot be empty."
-  end
-end
-
-##
-# main
-def main
-  unless $stdin.tty? && $stdout.tty?
-    warn "relay configure requires an interactive terminal"
-    throw(:exit, 1)
-  end
-  env = load_env
-  puts Relay.banner
-  puts "Relay configuration\n"
-  PROVIDERS.each do |provider|
-    key = provider.keys[0]
-    current = env[key] || provider.keys.find_map { ENV[_1] }
-    env[key] = prompt(provider.label, current:, secret: true)
-  end
-  name = prompt_required("Name")
-  email = prompt_required("Email")
-  password = prompt_password
-  write_env(env)
-  require File.join(Relay.root, "app", "init")
-  unless Relay::DB.table_exists?(:users)
-    warn "Relay has not been bootstrapped"
-    throw(:exit, 1)
-  end
-  user = Relay::Models::User.where(email:).first || Relay::Models::User.new(email:)
-  user.name = name
-  user.password = password
-  user.save
-  puts "\nConfigured Relay."
-  puts "Email: #{email}"
-end
-
-excode = catch(:exit) {
-  main
-  0
-}
-exit excode


### PR DESCRIPTION
## About

Change the default `RELAY_HOME` from `~/.relay` to `~/.config/relay`
to follow the XDG Base Directory specification.

## Changes

- `lib/relay.rb`: change default from `~/.relay` to `~/.config/relay`